### PR TITLE
Update article.bib

### DIFF
--- a/issues/2023/v16/41439/article.bib
+++ b/issues/2023/v16/41439/article.bib
@@ -1,6 +1,6 @@
 @chapter{haves1980identifying,
     title         = {Identifying the organization of writing processes},
-    author        = {R. Hayes, John and S. Flower, Linda},
+    author        = {Hayes, John R. and Flower, Linda S.},
     year          = {1980},
     journal       = {Cognitive processes in writing},
     publisher     = {Lawrence Erlbaum Assosiates},


### PR DESCRIPTION
Desculpe Leo. Inverti a ordem dos nomes dos autores na referência:
**R. HAYES**, John y **S. FLOWER**, Linda. Identifying the organization of writing processes. [S.l.]: Lawrence Erlbaum Assosiates, 1980.
Agora deverá imprimir como:
HAYES, **John R**. y FLOWER, **Linda S.**. Identifying the organization of writing processes. [S.l.]: Lawrence Erlbaum Assosiates, 1980.

Acabei me esquecendo que alguns caracteres em latex precisam ser precedidos por "\". Arrumei a URL da referência:
FLOWER, Linda y HAYES, J. Textos en contexto. Buenos Aires, Argentina: Asociación Internacional de Lectura, 1996. Disponible en: <http://www.a43d.com.uy/jenny/wp-content/uploads/2018/06/Flowers**%5C**_y**%5C**_Hayes.pdf>.