### PR TITLE
Update article.tex

### DIFF
--- a/issues/2023/v16/46865/article.tex
+++ b/issues/2023/v16/46865/article.tex
@@ -15,7 +15,7 @@
 \articledoi{10.1590/1983-3652.2023.46865}
 %\articleid{NNNN} % if the article ID is not the last 5 numbers of its DOI, provide it using \articleid{} commmand 
 % list of available sesscions in the journal: articles, dossier, reports, essays, reviews, interviews, editorial
-\articlesessionname{article}
+\articlesessionname{Articles}
 \runningauthor{Barbosa et al.} 
 %\editorname{Leonardo Araújo} % old template
 \sectioneditorname{Daniervelin Pereira}


### PR DESCRIPTION
Segundo os novos critérios da SciELO, as seções devem ser idênticas entre a planilha de other e o PDF. A seção de artigos originais na planilha de other da revista Texto Livre está como "Artigos/Articles/Artículos".