### PR TITLE
Update article.tex

### DIFF
--- a/issues/2023/v16/42167/article.tex
+++ b/issues/2023/v16/42167/article.tex
@@ -136,19 +136,19 @@
 \maketitle
 
 \begin{polyabstract}
+\begin{english}
 \begin{abstract}
 With the accelerating pace of technological developments, translation applications have emerged as the latest trend of machine translation to serve users’ needs for various purposes such as study, work, travel, and entertainment. While the goal of every service, including translation, is to attain user satisfaction, a greater understanding of users’ expectations is essential to improve translation applications and enhance the user experience. This study aims at exploring the users’ quality expectations of translation applications and the realistic features of the applications. A qualitative research design was used to analyze 240 user expectations selected purposefully from 12 popular translation applications. The descriptions given by the developers of the 12 applications were evaluated using \posscite{ryan_machine_1993} model to explore the correspondence between users’ expectations and realistic features of translation applications. The findings revealed a detailed list of quality service criteria and translation quality criteria as well as suggestions to improve both types of criteria. The study may have empirical and theoretical implications for translation researchers and translation application developers in the attempt to compile a comprehensive and realistic profile of translation application features and quality. The application users and human translators can also benefit from the findings.
 
 \keywords{Applications \sep Users’ expectations \sep Quality \sep Realistic features \sep Service}
 \end{abstract}
+\end{english}
 
-\begin{english}
 \begin{abstract}
 Com o ritmo acelerado dos desenvolvimentos tecnológicos, os aplicativos de tradução surgiram como a última tendência da tradução automática para atender às necessidades dos usuários para diversos fins, como estudo, trabalho, viagens e entretenimento. Embora o objetivo de todos os serviços, incluindo a tradução, seja alcançar a satisfação do utilizador, uma maior compreensão das expectativas dos utilizadores é essencial para melhorar as aplicações de tradução e melhorar a experiência do utilizador. Este estudo visa explorar as expectativas de qualidade dos usuários em relação aos aplicativos de tradução e os recursos realistas dos aplicativos. Um projeto de pesquisa qualitativa foi utilizado para analisar 240 expectativas de usuários selecionadas propositalmente em 12 aplicativos de tradução populares. As descrições fornecidas pelos desenvolvedores dos 12 aplicativos foram avaliadas usando o modelo de \textcite{ryan_machine_1993} para explorar a correspondência entre as expectativas dos usuários e as características realistas dos aplicativos de tradução. As conclusões revelaram uma lista detalhada de critérios de qualidade de serviço e critérios de qualidade de tradução, bem como sugestões para melhorar ambos os tipos de critérios. O estudo pode ter implicações empíricas e teóricas para pesquisadores de tradução e desenvolvedores de aplicativos de tradução na tentativa de compilar um perfil abrangente e realista dos recursos e da qualidade dos aplicativos de tradução. Os usuários do aplicativo e os tradutores humanos também podem se beneficiar das descobertas.
 
 \keywords{Aplicações \sep Expectativas dos usuários \sep Qualidade \sep Recursos realistas \sep Serviço}
 \end{abstract}
-\end{english}
 % if there is another abstract, insert it here using the same scheme
 \end{polyabstract}
 


### PR DESCRIPTION
Ambos resumos (inglês/português) estão com o mesmo título "abstract", não sei se essa alteração proposta irá resolver mas o intuito é fazer com que o título do resumo em português seja alterado de "abstract" para "resumo"