### PR TITLE
Update article.bib

### DIFF
--- a/issues/2024/v17/46380/article.bib
+++ b/issues/2024/v17/46380/article.bib
@@ -1,42 +1,11 @@
-@online{congresso2018,
-    author={{Congresso em Foco}},
-    title={Bandeira inspirada no nazismo é exibida em manifestação pró-Bolsonaro},
-    year={2018},
-    url={https://congressoemfoco.uol.com.br/area/pais/bandeira-inspirada-no-nazismo-e-exibida-em-manifestacao-pro-bolsonaro/}, 
-}
-
-@book{witt1958,
-    title         = {Philosophical investigations},
-    author        = {Wittgenstein, Ludwig},
-    year          = {1958},
-    publisher     = {Macmillan},
-    address       = {New York},
-}
-
-@book{brown1987politeness,
-    title         = {Politeness: Some universals in language usage},
-    author        = {Brown, Penelope and Levinson, Stephen C},
-    year          = {1987},
-    publisher     = {Cambridge University Press},
-    address       = {Cambridge},
-}
-
-@inproceedings{sweetser1988grammaticalization,
-    title         = {Grammaticalization and semantic bleaching},
-    author        = {Sweetser, Eve E.},
-    year          = {1988},
-    booktitle     = {Annual Meeting of the Berkeley Linguistics Society},
-    pages         = {389--405},
-}
-
-@book{van1996representation,
-    title         = {The representation of social actors},
-    author        = {Van Leeuwen, Theo},
-    year          = {1996},
-    booktitle     = {Texts and practices: Readings in critical discourse analysis},
-    address       = {London},
-    pages         = {32--71},
-    editor        = {Caldas-Coulthard, Carmen R and Coulthard, Malcom},
+@article{baele2021variations,
+    title         = {Variations on a theme? Comparing 4chan, 8kun, and other chans' far-right ``/pol'' boards},
+    author        = {Baele, Stephane J and Brace, Lewys and Coan, Travis G},
+    year          = {2021},
+    journal       = {Perspectives on Terrorism},
+    volume        = {15},
+    number        = {1},
+    pages         = {65--80},
 }
 
 @inproceedings{bernstein20114chan,
@@ -49,11 +18,40 @@
     pages         = {50--57},
 }
 
-@article{saklofske2011using,
-    title         = {Using 4chan. org to challenge the status quo illusion of media stability},
-    author        = {Saklofske, Jon},
-    year          = {2011},
-    journal       = {MIT7 unstable platforms: the promise and peril of transition. Cambridge, MA: MIT},
+@book{brown1987politeness,
+    title         = {Politeness: Some universals in language usage},
+    author        = {Brown, Penelope and Levinson, Stephen C},
+    year          = {1987},
+    publisher     = {Cambridge University Press},
+    address       = {Cambridge},
+}
+
+@article{colley2022challenges,
+    title         = {The challenges of studying 4chan and the Alt-Right:`Come on in the water's fine'},
+    author        = {Colley, Thomas and Moore, Martin},
+    year          = {2022},
+    journal       = {New Media \& Society},
+    volume        = {24},
+    number        = {1},
+    pages         = {5--30},
+}
+
+@misc{congresso2018,
+    author={Congresso em Foco},
+    title={Bandeira inspirada no nazismo é exibida em manifestação pró-Bolsonaro},
+    year={2018},
+    url={https://congressoemfoco.uol.com.br/area/pais/bandeira-inspirada-no-nazismo-e-exibida-em-manifestacao-pro-bolsonaro/}, 
+}
+
+
+@article{elley2021rebirth,
+    title         = {``The rebirth of the West begins with you!''--Self-improvement as radicalisation on 4chan},
+    author        = {Elley, Ben},
+    year          = {2021},
+    journal       = {Humanities and Social Sciences Communications},
+    volume        = {8},
+    number        = {1},
+    pages         = {1--10},
 }
 
 @inproceedings{fradin2015,
@@ -65,15 +63,152 @@
     editor        = {Gruyter Mouton},
 }
 
-@inproceedings{wodakreisigl2016,
-    title         = {The Discourse-Historical Approach},
-    author        = {Wodak, Ruth and Reisigl, Martin},
-    year          = {2016},
-    booktitle     = {Methods of critical discourse studies},
-    publisher     = {Sage Publications},
+@book{hagen2018,
+    title         = {Here I Am, Praying to an Egyptian Frog Exploring Political Fluidity on 4chan/pol/},
+    author        = {Hagen, Sal},
+    year          = {2018},
+    address       = {Amsterdam},
+}
+
+@article{hine2017kek,
+    title         = {Kek, cucks, and god emperor trump: A measurement study of 4chan's politically incorrect forum and its effects on the web},
+    author        = {Hine, Gabriel and Onaolapo, Jeremiah and De Cristofaro, Emiliano and Kourtellis, Nicolas and Leontiadis, Ilias and Samaras, Riginos and Stringhini, Gianluca and Blackburn, Jeremy},
+    year          = {2017},
+    url           = {arXiv:1610.03452},
+}
+
+@article{mittos2020analyzing,
+    title         = {Analyzing genetic testing discourse on the web through the lens of Twitter, Reddit, and 4chan},
+    author        = {Mittos, Alexandros and Zannettou, Savvas and Blackburn, Jeremy and Cristofaro, Emiliano De},
+    year          = {2020},
+    journal       = {ACM Transactions on the Web (TWEB)},
+    volume        = {14},
+    number        = {4},
+    pages         = {17:1--17:38},
+}
+
+@book{mouffe2018left,
+    title         = {For a left populism},
+    author        = {Mouffe, Chantal},
+    year          = {2018},
+}
+
+@book{nagle2017kill,
+    title         = {Kill all normies: Online culture wars from 4chan and Tumblr to Trump and the alt-right},
+    author        = {Nagle, Angela},
+    year          = {2017},
+}
+
+@misc{papasavva2020raiders,
+    title         = {Raiders of the lost kek: 3.5 years of augmented 4chan posts from the politically incorrect board},
+    author        = {Papasavva, Antonis and Zannettou, Savvas and De Cristofaro, Emiliano and Stringhini, Gianluca and Blackburn, Jeremy},
+    year          = {2020},
+    booktitle     = {Proceedings of the international AAAI conference on web and social media},
+    volume        = {14},
+    pages         = {885--894},
+}
+
+@article{peeters2021vernacular,
+    title         = {On the vernacular language games of an antagonistic online subculture},
+    author        = {Peeters, Stijn and Tuters, Marc and Willaert, Tom and De Zeeuw, Daniel},
+    year          = {2021},
+    journal       = {Frontiers in Big Data},
+    volume        = {4},
+}
+
+@book{richardson2017british,
+    title         = {British Fascism: a discourse-historical analysis [Preface]},
+    author        = {Richardson, John},
+    year          = {2017},
+    publisher     = {Suttgart Press},
+    address       = {Suttgart},
+}
+
+@article{saklofske2011using,
+    title         = {Using 4chan. org to challenge the status quo illusion of media stability},
+    author        = {Saklofske, Jon},
+    year          = {2011},
+    journal       = {MIT7 unstable platforms: the promise and peril of transition. Cambridge, MA: MIT},
+}
+
+@inproceedings{sweetser1988grammaticalization,
+    title         = {Grammaticalization and semantic bleaching},
+    author        = {Sweetser, Eve E.},
+    year          = {1988},
+    booktitle     = {Annual Meeting of the Berkeley Linguistics Society},
+    pages         = {389--405},
+}
+
+@article{tuters2018larping,
+    title         = {LARPing \& liberal tears: Irony, belief and idiocy in the deep vernacular web},
+    author        = {Tuters, Marc},
+    year          = {2018},
+    journal       = {Post-Digital Cultures of the Far Right.},
+    pages         = {37--48},
+}
+
+@inproceedings{tuters2020esoteric,
+    title         = {Esoteric Fascism Online: 4chan and the Kali Yuga},
+    author        = {Tuters, Marc},
+    year          = {2020},
+    booktitle     = {Far-Right Revisionism and the End of History},
+    publisher     = {Routledge},
+    pages         = {286--303},
+}
+
+@misc{tuters2021meme,
+    title         = {Why meme magic is real but memes are not: on order words, refrains and the deep vernacular web},
+    author        = {Tuters, Marc},
+    year          = {2021},
+    pages         = {46--59},
+}
+
+@article{tutershagen2020they,
+    title         = {(((They))) rule: Memetic antagonism and nebulous othering on 4chan},
+    author        = {Tuters, Marc and Hagen, Sal},
+    year          = {2020},
+    journal       = {New Media \& Society},
+    volume        = {22},
+    number        = {12},
+    pages         = {2218--2237},
+}
+
+@book{van1996representation,
+    title         = {The representation of social actors},
+    author        = {Van Leeuwen, Theo},
+    year          = {1996},
+    booktitle     = {Texts and practices: Readings in critical discourse analysis},
     address       = {London},
-    pages         = {23--62},
-    editor        = {Wodak, Ruth and Meyer, Michael},
+    pages         = {32--71},
+    editor        = {Caldas-Coulthard, Carmen R and Coulthard, Malcom},
+}
+
+@book{witt1958,
+    title         = {Philosophical investigations},
+    author        = {Wittgenstein, Ludwig},
+    year          = {1958},
+    publisher     = {Macmillan},
+    address       = {New York},
+}
+
+@article{wodak2018rand,
+    title         = {Vom Rand in die Mitte--,,Schamlose Normalisierung``},
+    author        = {Wodak, Ruth},
+    year          = {2018},
+    journal       = {Politische Vierteljahresschrift},
+    volume        = {59},
+    number        = {2},
+    pages         = {323--335},
+}
+
+@article{wodak2021shameless,
+    title         = {Shameless normalisation of impoliteness: Berlusconi's and Trump's press conferences},
+    author        = {Wodak, Ruth and Culpeper, Jonathan and Semino, Elena},
+    year          = {2021},
+    journal       = {Discourse \& Society},
+    volume        = {32},
+    number        = {3},
+    pages         = {369--393},
 }
 
 @inproceedings{wodameyer2016,
@@ -87,56 +222,15 @@
     editor        = {Wodak, Ruth and Meyer, Michael},
 }
 
-@article{hine2017kek,
-    title         = {Kek, cucks, and god emperor trump: A measurement study of 4chan's politically incorrect forum and its effects on the web},
-    author        = {Hine, Gabriel and Onaolapo, Jeremiah and De Cristofaro, Emiliano and Kourtellis, Nicolas and Leontiadis, Ilias and Samaras, Riginos and Stringhini, Gianluca and Blackburn, Jeremy},
-    year          = {2017},
-    url           = {arXiv:1610.03452},
-}
-
-@book{nagle2017kill,
-    title         = {Kill all normies: Online culture wars from 4chan and Tumblr to Trump and the alt-right},
-    author        = {Nagle, Angela},
-    year          = {2017},
-}
-
-@book{richardson2017british,
-    title         = {British Fascism: a discourse-historical analysis [Preface]},
-    author        = {Richardson, John},
-    year          = {2017},
-    publisher     = {Suttgart Press},
-    address       = {Suttgart},
-}
-
-@book{hagen2018,
-    title         = {Here I Am, Praying to an Egyptian Frog Exploring Political Fluidity on 4chan/pol/},
-    author        = {Hagen, Sal},
-    year          = {2018},
-    address       = {Amsterdam},
-}
-
-@book{mouffe2018left,
-    title         = {For a left populism},
-    author        = {Mouffe, Chantal},
-    year          = {2018},
-}
-
-@article{tuters2018larping,
-    title         = {LARPing \& liberal tears: Irony, belief and idiocy in the deep vernacular web},
-    author        = {Tuters, Marc},
-    year          = {2018},
-    journal       = {Post-Digital Cultures of the Far Right.},
-    pages         = {37--48},
-}
-
-@article{wodak2018rand,
-    title         = {Vom Rand in die Mitte--,,Schamlose Normalisierung``},
-    author        = {Wodak, Ruth},
-    year          = {2018},
-    journal       = {Politische Vierteljahresschrift},
-    volume        = {59},
-    number        = {2},
-    pages         = {323--335},
+@inproceedings{wodakreisigl2016,
+    title         = {The Discourse-Historical Approach},
+    author        = {Wodak, Ruth and Reisigl, Martin},
+    year          = {2016},
+    booktitle     = {Methods of critical discourse studies},
+    publisher     = {Sage Publications},
+    address       = {London},
+    pages         = {23--62},
+    editor        = {Wodak, Ruth and Meyer, Michael},
 }
 
 @misc{zannettou2018origins,
@@ -144,97 +238,4 @@
     author        = {Zannettou, Savvas and Caulfield, Tristan and Blackburn, Jeremy and De Cristofaro, Emiliano and Sirivianos, Michael and Stringhini, Gianluca and Suarez-Tangil, Guillermo},
     year          = {2018},
     pages         = {188--202},
-}
-
-@article{mittos2020analyzing,
-    title         = {Analyzing genetic testing discourse on the web through the lens of Twitter, Reddit, and 4chan},
-    author        = {Mittos, Alexandros and Zannettou, Savvas and Blackburn, Jeremy and Cristofaro, Emiliano De},
-    year          = {2020},
-    journal       = {ACM Transactions on the Web (TWEB)},
-    volume        = {14},
-    number        = {4},
-    pages         = {17:1--17:38},
-}
-
-@misc{papasavva2020raiders,
-    title         = {Raiders of the lost kek: 3.5 years of augmented 4chan posts from the politically incorrect board},
-    author        = {Papasavva, Antonis and Zannettou, Savvas and De Cristofaro, Emiliano and Stringhini, Gianluca and Blackburn, Jeremy},
-    year          = {2020},
-    booktitle     = {Proceedings of the international AAAI conference on web and social media},
-    volume        = {14},
-    pages         = {885--894},
-}
-
-@inproceedings{tuters2020esoteric,
-    title         = {Esoteric Fascism Online: 4chan and the Kali Yuga},
-    author        = {Tuters, Marc},
-    year          = {2020},
-    booktitle     = {Far-Right Revisionism and the End of History},
-    publisher     = {Routledge},
-    pages         = {286--303},
-}
-
-@article{tutershagen2020they,
-    title         = {(((They))) rule: Memetic antagonism and nebulous othering on 4chan},
-    author        = {Tuters, Marc and Hagen, Sal},
-    year          = {2020},
-    journal       = {New Media \& Society},
-    volume        = {22},
-    number        = {12},
-    pages         = {2218--2237},
-}
-
-@article{baele2021variations,
-    title         = {Variations on a theme? Comparing 4chan, 8kun, and other chans' far-right ``/pol'' boards},
-    author        = {Baele, Stephane J and Brace, Lewys and Coan, Travis G},
-    year          = {2021},
-    journal       = {Perspectives on Terrorism},
-    volume        = {15},
-    number        = {1},
-    pages         = {65--80},
-}
-
-@article{elley2021rebirth,
-    title         = {``The rebirth of the West begins with you!''--Self-improvement as radicalisation on 4chan},
-    author        = {Elley, Ben},
-    year          = {2021},
-    journal       = {Humanities and Social Sciences Communications},
-    volume        = {8},
-    number        = {1},
-    pages         = {1--10},
-}
-
-@article{peeters2021vernacular,
-    title         = {On the vernacular language games of an antagonistic online subculture},
-    author        = {Peeters, Stijn and Tuters, Marc and Willaert, Tom and De Zeeuw, Daniel},
-    year          = {2021},
-    journal       = {Frontiers in Big Data},
-    volume        = {4},
-}
-
-@misc{tuters2021meme,
-    title         = {Why meme magic is real but memes are not: on order words, refrains and the deep vernacular web},
-    author        = {Tuters, Marc},
-    year          = {2021},
-    pages         = {46--59},
-}
-
-@article{wodak2021shameless,
-    title         = {Shameless normalisation of impoliteness: Berlusconi's and Trump's press conferences},
-    author        = {Wodak, Ruth and Culpeper, Jonathan and Semino, Elena},
-    year          = {2021},
-    journal       = {Discourse \& Society},
-    volume        = {32},
-    number        = {3},
-    pages         = {369--393},
-}
-
-@article{colley2022challenges,
-    title         = {The challenges of studying 4chan and the Alt-Right:`Come on in the water's fine'},
-    author        = {Colley, Thomas and Moore, Martin},
-    year          = {2022},
-    journal       = {New Media \& Society},
-    volume        = {24},
-    number        = {1},
-    pages         = {5--30},
 }


### PR DESCRIPTION
Mesmo caso do artigo e42708, somente foram incluídas/reordenadas no arquivo .bib as referências efetivamente citadas. A ref. Congresso em foco (2018) foi inserida em article.bib pois constava somente no article.bib.original e acabou não sendo impressa no PDF