### PR TITLE
Update article.bib

### DIFF
--- a/issues/2024/v17/49369/article.bib
+++ b/issues/2024/v17/49369/article.bib
@@ -299,7 +299,7 @@
 
 @phdthesis{olivar2020tratamiento,
     title         = {Tratamiento informativo sobre las principales causas externas de muerte en la prensa digital espa{\~n}ola (2010-2017)},
-    author        = {Olivar-Juli{\'a}n},
+    author        = {Olivar-Juli{\'a}n, J},
     year          = {2020},
     url           = {https://reunir.unir.net/handle/123456789/10846},
     editor        = {Segado-Boj, D Francisco and D{\'\i}az-Campo, D Jes{\'u}s},


### PR DESCRIPTION
De acordo com a fonte fornecida (URL) notei que o nome do autor da referência está incompleto. Citación:  Olivar-Julián, J. (2020). Tratamiento informativo sobre las principales causas externas de muerte en la prensa digital española (2010-2017) [Tesis doctoral, UNIR]. Re-UNIR. https://reunir.unir.net/handle/123456789/10846.

O nome do autor é Javier Olivar-Julián (Olivar-Julián, J)